### PR TITLE
CameraHandler: Do not call streamStop() with lock held

### DIFF
--- a/src/CameraHandler.cpp
+++ b/src/CameraHandler.cpp
@@ -456,14 +456,16 @@ void CameraHandler::streamStop(domid_t domId, const xencamera_req& aReq,
         return;
     }
 
-    std::lock_guard<std::mutex> lock(mLock);
+    std::unique_lock<std::mutex> lock(mLock);
 
     DLOG(mLog, DEBUG) << "Handle command [STREAM STOP] dom " <<
         std::to_string(domId);
 
     mStreamingNow.erase(domId);
-    if (!mStreamingNow.size())
+    if (!mStreamingNow.size()) {
+        lock.unlock();
         mCamera->streamStop();
+    }
 }
 
 void CameraHandler::release()


### PR DESCRIPTION
The problem is that streamStop() needs to wait for eventThread to
finish which in turn might hold the same lock if there is a work
to do, see CommandHandler::onFrameDoneCallback() for details.

If the streamStop() *must* be protected by the lock, we need either
consider dropping the lock from onFrameDoneCallback() or terminate
eventThread forcely.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>