### PR TITLE
Add support for partial zero-copy

### DIFF
--- a/src/CameraHandler.hpp
+++ b/src/CameraHandler.hpp
@@ -60,7 +60,7 @@ public:
                     xencamera_resp& aResp);
 
     /* data, size */
-    typedef std::function<void(uint8_t *, size_t)> FrameListener;
+    typedef std::function<void(uint8_t *, size_t, bool)> FrameListener;
     /* name, value */
     typedef std::function<void(const std::string, int64_t)> ControlListener;
 
@@ -71,6 +71,9 @@ public:
 
     void listenerSet(domid_t domId, Listeners listeners);
     void listenerReset(domid_t domId);
+
+    void bufRegister(FrontendBufferPtr buf);
+    void bufUnregister(FrontendBufferPtr buf);
 
 private:
     XenBackend::Log mLog;
@@ -113,7 +116,7 @@ private:
     void init(std::string uniqueId);
     void release();
 
-    void onFrameDoneCallback(int index, int size);
+    void onFrameDoneCallback(int index, unsigned long cdata, int size);
 
     void parseUniqueId(const std::string& uniqueId, std::string& videoId,
         std::string& mediaId);

--- a/src/CommandHandler.hpp
+++ b/src/CommandHandler.hpp
@@ -97,7 +97,7 @@ private:
     void streamStart(const xencamera_req& aReq, xencamera_resp& aResp);
     void streamStop(const xencamera_req& aReq, xencamera_resp& aResp);
 
-    void onFrameDoneCallback(uint8_t *data, size_t size);
+    void onFrameDoneCallback(uint8_t *data, size_t size, bool do_hw);
     void onCtrlChangeCallback(const std::string name, int64_t value);
 };
 

--- a/src/FrontendBuffer.cpp
+++ b/src/FrontendBuffer.cpp
@@ -14,6 +14,9 @@ using XenBackend::Exception;
 
 FrontendBuffer::FrontendBuffer(domid_t domId, size_t size,
                                const xencamera_req& req) :
+    mInHw(false),
+    mInQueue(false),
+    mInCleanup(false),
     mLog("FrontendBuffer"),
     mDomId(domId)
 {

--- a/src/FrontendBuffer.hpp
+++ b/src/FrontendBuffer.hpp
@@ -9,6 +9,7 @@
 #define SRC_FRONTENDBUFFER_HPP_
 
 #include <memory>
+#include <atomic>
 
 #include <xen/be/Log.hpp>
 #include <xen/be/XenGnttab.hpp>
@@ -26,6 +27,20 @@ public:
     }
 
     void copyBuffer(void *data, size_t size);
+    void* getBuffer() {
+        return mBuffer->get();
+    }
+    size_t getSize() {
+        return mBuffer->size();
+    }
+
+    // Flag to signal that buffer is in use by hardware
+    std::atomic<bool> mInHw;
+    // Flag to signal that buffer is queued for processing
+    std::atomic<bool> mInQueue;
+    // Flag to signal that buffer is queued for deletion
+    std::atomic<bool> mInCleanup;
+    int mLastIndex = -1;
 
 private:
     XenBackend::Log mLog;
@@ -44,6 +59,6 @@ private:
                        std::vector<grant_ref_t>& refs);
 };
 
-typedef std::unique_ptr<FrontendBuffer> FrontendBufferPtr;
+typedef std::shared_ptr<FrontendBuffer> FrontendBufferPtr;
 
 #endif /* SRC_FRONTENDBUFFER_HPP_ */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@ using XenBackend::Utils;
 
 string gLogFileName;
 string gCfgFileName;
+bool gZeroCopy = true;
 
 int gRetStatus = EXIT_SUCCESS;
 
@@ -80,7 +81,7 @@ bool commandLineOptions(int argc, char *argv[])
 {
     int opt = -1;
 
-    while((opt = getopt(argc, argv, "c:v:l:fh?")) != -1) {
+    while((opt = getopt(argc, argv, "c:v:l:fhz?")) != -1) {
         switch(opt) {
         case 'v':
             if (!Log::setLogMask(string(optarg)))
@@ -97,6 +98,10 @@ bool commandLineOptions(int argc, char *argv[])
 
         case 'c':
             gCfgFileName = optarg;
+            break;
+        case 'z':
+            gZeroCopy = false;
+            LOG("Main", INFO) << "Disabling zero copy";
             break;
 
         default:


### PR DESCRIPTION
This feature is enabled by default and can be disabled by passing -z flag to camera_be.

This commit adds support for zero-copy operation for 1 frontend usecase. This is done by passing the frontend buffers as USERPTR buffers to the v4l2.

In the case of multiple frontends, some frontend buffers are used as USERPTR and memcpy is done for the rest of the frontends.

To prevent leaking of one frontend's buffer modifications to another ones, a strict order of operations is ensured. We first perform all of the memcopy operations and only release the original buffer after.

In the case of one of the frontends freezing or stopping the stream, it's buffers are swapped on the fly with the ones from the different frontend.